### PR TITLE
Convert double to int to fix floating point comparison

### DIFF
--- a/lib/src/circular_notched_and_cornered_shape.dart
+++ b/lib/src/circular_notched_and_cornered_shape.dart
@@ -64,14 +64,17 @@ class CircularNotchedAndCorneredRectangle extends NotchedShape {
       return Path()..addRect(host);
     }
 
-    if (guest.center.dx == host.width / 2) {
+    final guestCenterDx = guest.center.dx.toInt();
+    final halfOfHostWidth = host.width ~/ 2;
+
+    if (guestCenterDx == halfOfHostWidth) {
       if (gapLocation != GapLocation.center)
         throw GapLocationException(
             'Wrong gap location in $AnimatedBottomNavigationBar towards FloatingActionButtonLocation => '
             'consider use ${GapLocation.center} instead of $gapLocation or change FloatingActionButtonLocation');
     }
 
-    if (guest.center.dx != host.width / 2) {
+    if (guestCenterDx != halfOfHostWidth) {
       if (gapLocation != GapLocation.end)
         throw GapLocationException(
             'Wrong gap location in $AnimatedBottomNavigationBar towards FloatingActionButtonLocation => '


### PR DESCRIPTION
The `GapLocationException` could be mistakenly thrown when comparing `guest.center.dx == host.width / 2` as both values are doubles. This led to the navigation bar showing up as a blank state. Refer to the screen recording and screen shots attached for reference.

![Screenshot_20210818-132255](https://user-images.githubusercontent.com/35050056/129858836-be47f06e-2c3e-4c5d-b26e-590ee18008fe.jpg)


https://user-images.githubusercontent.com/35050056/129859179-f5a35c7a-6d01-4aaa-a694-2cc8d46c7201.mp4

