### PR TITLE
Reuse animation controller

### DIFF
--- a/lib/animated_bottom_navigation_bar.dart
+++ b/lib/animated_bottom_navigation_bar.dart
@@ -312,34 +312,22 @@ class _AnimatedBottomNavigationBarState
     extends State<AnimatedBottomNavigationBar> with TickerProviderStateMixin {
   late ValueListenable<ScaffoldGeometry> geometryListenable;
 
-  late AnimationController _bubbleController;
+  late final AnimationController _bubbleController;
+  late final CurvedAnimation bubbleCurve;
+
 
   double _bubbleRadius = 0;
   double _iconScale = 1;
 
   @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    geometryListenable = Scaffold.geometryOf(context);
-
-    widget.notchAndCornersAnimation?..addListener(() => setState(() {}));
-  }
-
-  @override
-  void didUpdateWidget(AnimatedBottomNavigationBar oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (widget.activeIndex != oldWidget.activeIndex) {
-      _startBubbleAnimation();
-    }
-  }
-
-  _startBubbleAnimation() {
+  void initState() {
+    super.initState();
     _bubbleController = AnimationController(
       duration: Duration(milliseconds: widget.splashSpeedInMilliseconds ?? 300),
       vsync: this,
     );
 
-    final bubbleCurve = CurvedAnimation(
+    bubbleCurve = CurvedAnimation(
       parent: _bubbleController,
       curve: Curves.linear,
     );
@@ -360,11 +348,30 @@ class _AnimatedBottomNavigationBarState
           }
         });
       });
+  }
 
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    geometryListenable = Scaffold.geometryOf(context);
+
+    widget.notchAndCornersAnimation?..addListener(() => setState(() {}));
+  }
+
+  @override
+  void didUpdateWidget(AnimatedBottomNavigationBar oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.activeIndex != oldWidget.activeIndex) {
+      _startBubbleAnimation();
+    }
+  }
+
+  _startBubbleAnimation() {
+    // Stop animation if it's currently running
     if (_bubbleController.isAnimating) {
       _bubbleController.reset();
     }
-    _bubbleController.forward();
+    _bubbleController.forward(from: 0);
   }
 
   @override

--- a/lib/animated_bottom_navigation_bar.dart
+++ b/lib/animated_bottom_navigation_bar.dart
@@ -313,8 +313,6 @@ class _AnimatedBottomNavigationBarState
   late ValueListenable<ScaffoldGeometry> geometryListenable;
 
   late final AnimationController _bubbleController;
-  late final CurvedAnimation bubbleCurve;
-
 
   double _bubbleRadius = 0;
   double _iconScale = 1;
@@ -327,7 +325,7 @@ class _AnimatedBottomNavigationBarState
       vsync: this,
     );
 
-    bubbleCurve = CurvedAnimation(
+    var bubbleCurve = CurvedAnimation(
       parent: _bubbleController,
       curve: Curves.linear,
     );

--- a/lib/animated_bottom_navigation_bar.dart
+++ b/lib/animated_bottom_navigation_bar.dart
@@ -325,7 +325,7 @@ class _AnimatedBottomNavigationBarState
       vsync: this,
     );
 
-    var bubbleCurve = CurvedAnimation(
+    final bubbleCurve = CurvedAnimation(
       parent: _bubbleController,
       curve: Curves.linear,
     );


### PR DESCRIPTION
I encountered a bug in #70 that required fixing. When a user clicks on one of the tabs, the library creates a new `AnimationController` every time, granted it only initializes the variable if a user clicks once, causing #70. 
To resolve the issue and prevent leaking `AnimationController` instances, I moved the code responsible for creating the `AnimationController` into the `initState` method and ensured that we started a forward animation from 0 instead of the current value.


Fixes #70 