### PR TITLE
fix: implement threshold-based FAB position validation

### DIFF
--- a/lib/src/circular_notched_and_cornered_shape.dart
+++ b/lib/src/circular_notched_and_cornered_shape.dart
@@ -63,22 +63,26 @@ class CircularNotchedAndCorneredRectangle extends NotchedShape {
       }
       return Path()..addRect(host);
     }
+    
+    final guestCenterDx = guest.center.dx;
+    final halfOfHostWidth = host.width / 2;
+    
+    final threshold = host.width * 0.1;  // 10% tolerance
+    final distanceFromCenter = (guestCenterDx - halfOfHostWidth).abs();
+    final isNearCenter = distanceFromCenter <= threshold;
 
-    final guestCenterDx = guest.center.dx.toInt();
-    final halfOfHostWidth = host.width ~/ 2;
-
-    if (guestCenterDx == halfOfHostWidth) {
-      if (gapLocation != GapLocation.center)
-        throw GapLocationException(
-            'Wrong gap location in $AnimatedBottomNavigationBar towards FloatingActionButtonLocation => '
-            'consider use ${GapLocation.center} instead of $gapLocation or change FloatingActionButtonLocation');
+    if (isNearCenter && gapLocation != GapLocation.center) {
+      throw GapLocationException(
+        'Wrong gap location in $AnimatedBottomNavigationBar towards FloatingActionButtonLocation => '
+        'consider use ${GapLocation.center} instead of $gapLocation or change FloatingActionButtonLocation'
+      );
     }
 
-    if (guestCenterDx != halfOfHostWidth) {
-      if (gapLocation != GapLocation.end)
-        throw GapLocationException(
-            'Wrong gap location in $AnimatedBottomNavigationBar towards FloatingActionButtonLocation => '
-            'consider use ${GapLocation.end} instead of $gapLocation or change FloatingActionButtonLocation');
+    if (!isNearCenter && gapLocation != GapLocation.end) {
+      throw GapLocationException(
+        'Wrong gap location in $AnimatedBottomNavigationBar towards FloatingActionButtonLocation => '
+        'consider use ${GapLocation.end} instead of $gapLocation or change FloatingActionButtonLocation'
+      );
     }
 
     // The guest's shape is a circle bounded by the guest rectangle.

--- a/lib/src/circular_notched_and_cornered_shape.dart
+++ b/lib/src/circular_notched_and_cornered_shape.dart
@@ -68,14 +68,14 @@ class CircularNotchedAndCorneredRectangle extends NotchedShape {
     final halfOfHostWidth = host.width ~/ 2;
 
     if (guestCenterDx == halfOfHostWidth) {
-      if (gapLocation == GapLocation.end)
+      if (gapLocation != GapLocation.center)
         throw GapLocationException(
             'Wrong gap location in $AnimatedBottomNavigationBar towards FloatingActionButtonLocation => '
             'consider use ${GapLocation.center} instead of $gapLocation or change FloatingActionButtonLocation');
     }
 
     if (guestCenterDx != halfOfHostWidth) {
-      if (gapLocation == GapLocation.center)
+      if (gapLocation != GapLocation.end)
         throw GapLocationException(
             'Wrong gap location in $AnimatedBottomNavigationBar towards FloatingActionButtonLocation => '
             'consider use ${GapLocation.end} instead of $gapLocation or change FloatingActionButtonLocation');


### PR DESCRIPTION
Fixes #87 

The previous implementation used exact integer comparison which was too strict for real-world scenarios. This change introduces a threshold-based approach that:

- Uses 10% of the navigation bar width as tolerance
- Better handles floating-point precision
- Maintains proper alignment validation
- Provides more reliable position detection

**Changes made:**

- Replaced integer comparison with double values
- Added threshold calculation (10% of width)
- Updated validation logic to use distance-based checks
- Maintained original validation intent while being more practical

**Test Cases:**

- Centered FAB with GapLocation.center now works properly
- End-positioned FAB with GapLocation.end continues to work
- Slight misalignments (within 10% threshold) are properly handled


Note: The previous fix in #23  was a step in the right direction but didn't fully resolve the position validation issues. This PR builds on that work to provide a more robust solution.