### PR TITLE
Added Optional Labels Below Icons

### DIFF
--- a/lib/animated_bottom_navigation_bar.dart
+++ b/lib/animated_bottom_navigation_bar.dart
@@ -192,6 +192,7 @@ class AnimatedBottomNavigationBar extends StatefulWidget {
     required List<IconData> icons,
     required int activeIndex,
     required Function(int) onTap,
+    List<String>? labels,
     double? height,
     double? splashRadius,
     int? splashSpeedInMilliseconds,
@@ -222,6 +223,7 @@ class AnimatedBottomNavigationBar extends StatefulWidget {
   }) : this._internal(
           key: key,
           icons: icons,
+          labels: labels,
           activeIndex: activeIndex,
           onTap: onTap,
           height: height,

--- a/lib/animated_bottom_navigation_bar.dart
+++ b/lib/animated_bottom_navigation_bar.dart
@@ -29,6 +29,9 @@ class AnimatedBottomNavigationBar extends StatefulWidget {
   /// Icon data to render in the tab bar.
   final List<IconData>? icons;
 
+  /// Labels to render under icons in the tab bar.
+  final List<String>? labels;
+
   /// Handler which is passed every updated active index.
   final Function(int) onTap;
 
@@ -37,6 +40,9 @@ class AnimatedBottomNavigationBar extends StatefulWidget {
 
   /// Optional custom size for each tab bar icon. Default is 24.
   final double? iconSize;
+
+  /// Optional custom size for each tab bar label. Default is 12.
+  final double? labelSize;
 
   /// Optional custom tab bar height. Default is 56.
   final double? height;
@@ -132,6 +138,7 @@ class AnimatedBottomNavigationBar extends StatefulWidget {
       this.tabBuilder,
       this.itemCount,
       this.icons,
+      this.labels,
       this.height,
       this.splashRadius = _defaultSplashRadius,
       this.splashSpeedInMilliseconds,
@@ -144,6 +151,7 @@ class AnimatedBottomNavigationBar extends StatefulWidget {
       this.leftCornerRadius,
       this.rightCornerRadius,
       this.iconSize,
+      this.labelSize,
       this.notchSmoothness,
       this.gapLocation,
       this.gapWidth,
@@ -196,6 +204,7 @@ class AnimatedBottomNavigationBar extends StatefulWidget {
     double? leftCornerRadius,
     double? rightCornerRadius,
     double? iconSize,
+    double? labelSize,
     NotchSmoothness? notchSmoothness,
     GapLocation? gapLocation,
     double? gapWidth,
@@ -227,6 +236,7 @@ class AnimatedBottomNavigationBar extends StatefulWidget {
           leftCornerRadius: leftCornerRadius ?? 0,
           rightCornerRadius: rightCornerRadius ?? 0,
           iconSize: iconSize,
+          labelSize: labelSize,
           notchSmoothness: notchSmoothness,
           gapLocation: gapLocation ?? GapLocation.end,
           gapWidth: gapWidth,
@@ -487,6 +497,8 @@ class _AnimatedBottomNavigationBarState
           iconScale: _iconScale,
           iconSize: widget.iconSize,
           onTap: () => widget.onTap(i),
+          label: widget.labels?.elementAt(i),
+          labelSize: widget.labelSize,
         ),
       );
 

--- a/lib/src/navigation_bar_item.dart
+++ b/lib/src/navigation_bar_item.dart
@@ -14,6 +14,8 @@ class NavigationBarItem extends StatelessWidget {
   final double? iconSize;
   final VoidCallback onTap;
   final Widget? child;
+  final String? label;
+  final double? labelSize;
 
   NavigationBarItem({
     required this.isActive,
@@ -27,6 +29,8 @@ class NavigationBarItem extends StatelessWidget {
     required this.iconSize,
     required this.onTap,
     this.child,
+    this.label,
+    this.labelSize,
   });
 
   @override
@@ -49,6 +53,8 @@ class NavigationBarItem extends StatelessWidget {
                 activeColor: activeColor,
                 inactiveColor: inactiveColor,
                 child: child,
+                label: label,
+                labelSize: labelSize,
               ),
             ),
             splashColor: Colors.transparent,

--- a/lib/src/tab_item.dart
+++ b/lib/src/tab_item.dart
@@ -7,6 +7,8 @@ class TabItem extends StatelessWidget {
   final Color? activeColor;
   final Color? inactiveColor;
   final Widget? child;
+  final String? label;
+  final double? labelSize;
 
   const TabItem({
     Key? key,
@@ -16,16 +18,34 @@ class TabItem extends StatelessWidget {
     this.activeColor = Colors.deepPurpleAccent,
     this.inactiveColor = Colors.black,
     this.child,
+    this.label,
+    this.labelSize = 12,
   }) : super(key: key);
 
   @override
   Widget build(BuildContext context) => child ?? _buildDefaultTab();
 
   Widget _buildDefaultTab() {
-    return Icon(
-      iconData,
-      color: isActive ? activeColor : inactiveColor,
-      size: iconSize,
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Icon(
+          iconData,
+          color: isActive ? activeColor : inactiveColor,
+          size: iconSize,
+        ),
+        if (label != null) ...[
+          const SizedBox(height: 4),
+          Text(
+            label!,
+            style: TextStyle(
+              color: isActive ? activeColor : inactiveColor,
+              fontSize: labelSize,
+            ),
+          ),
+        ],
+      ],
     );
   }
 }


### PR DESCRIPTION
I added option to add labels below Icons. 
These are just optional. 
There is no change to anywhere in the code but the added optional labels.

Both of the below images are with this version of the animated-bottom-navigation-bar.

Just Icons:
![Screenshot_1](https://github.com/user-attachments/assets/19910151-2424-41ae-b997-407e2cb762de)

With labels:
![Screenshot_2](https://github.com/user-attachments/assets/3fe32dda-30a6-4ec7-9c46-05bbc595428a)
