### PR TITLE
Fix: Blur effect causes bottom navigation bar to rebuild without corner radius & notch #93

### DIFF
--- a/lib/animated_bottom_navigation_bar.dart
+++ b/lib/animated_bottom_navigation_bar.dart
@@ -405,14 +405,14 @@ class _AnimatedBottomNavigationBarState
             ? VisibleAnimator(
                 showController: widget.hideAnimationController!,
                 curve: widget.hideAnimationCurve ?? Curves.fastOutSlowIn,
-                child: _buildBottomBar(context),
+                child: _buildBottomBar(context, clipper),
               )
-            : _buildBottomBar(context),
+            : _buildBottomBar(context, clipper),
       ),
     );
   }
 
-  Widget _buildBottomBar(BuildContext context) {
+  Widget _buildBottomBar(BuildContext context, CustomClipper<Path> clipper) {
     final backgroundColor = widget.backgroundColor ?? Colors.white;
     final bottomBarBackgroundColor = widget.backgroundGradient != null
         ? Colors.transparent
@@ -429,7 +429,8 @@ class _AnimatedBottomNavigationBarState
           left: widget.safeAreaValues.left,
           right: widget.safeAreaValues.right,
           child: widget.blurEffect
-              ? ClipRect(
+              ? ClipPath(
+                clipper: clipper,
                   child: BackdropFilter(
                     filter: widget.blurFilter ??
                         ImageFilter.blur(sigmaX: 5, sigmaY: 10),


### PR DESCRIPTION
### Issue 
Fixes #93 
When **blurEffect** is enabled, navigation bar briefly loses corner radius and notch when some item is selected.
### Cause 
It was occuring because **BackDropFilter** (who was supposed to produce blur effect) was wrapped in a **ClipRect**. So when it was rebuilding, it would blur full rectangle it was provided for a moment.
### Fix 
Replaced **ClipRect** with **ClipPath** and added the actual clipper which defines radius and notch path. Now it rebuilds but maintains corner radius and notch.